### PR TITLE
Pipeline example - regridding diffusion outputs

### DIFF
--- a/examples/2-regrid-evaluate-gorce/README.md
+++ b/examples/2-regrid-evaluate-gorce/README.md
@@ -8,21 +8,21 @@ Data is available from two Zenodo repositories:
 
 ## Prerequisites
 
-Install xESMF for regridding:
+Create a conda environment and install xESMF (required for regridding). Then create a pip venv with access to the conda packages using `--system-site-packages`:
 
 ```bash
+conda create -n nemo python=3.10
+conda activate nemo
 conda install -c conda-forge xesmf
+
+python -m venv venv --system-site-packages
+source venv/bin/activate
 ```
 
-Install the nemo-spinup-restart tool (from the repo root):
+Install the nemo-spinup-restart and nemo-spinup-evaluation tools (from the repo root):
 
 ```bash
 pip install ./nemo-spinup-restart
-```
-
-Install nemo-spinup-evaluation (from the repo root):
-
-```bash
 pip install ./nemo-spinup-evaluation
 ```
 
@@ -60,17 +60,20 @@ This runs the `nemo-upscale` tool which:
 3. Regrids to fine (0.25-degree) resolution using xESMF bilinear interpolation
 4. Applies the fine resolution mask and zeros out velocities for NEMO to recompute
 
-Output is written to `./generated/`.
+Output is written to `./generated/coarse/` and `./generated/fine/`.
 
-## Evaluate using nemo-spinup-evaluationuation
+## Evaluate using nemo-spinup-evaluation
 
-Evaluate the generated restart file against reference diagnostics:
+Evaluate the generated restart files at both resolutions. There are separate configs for the coarse (1-degree) and fine (0.25-degree) restart files:
+
+- `gen-setup-100.yaml` — evaluates the coarse restart
+- `gen-setup-025.yaml` — evaluates the fine restart
 
 ```bash
 bash evaluate.sh
 ```
 
-Results are saved to `./results/`.
+Results are saved to `./results/` with prefixes `gen-C2-100` and `gen-C2-025`.
 
 ## Running the full pipeline
 

--- a/examples/2-regrid-evaluate-gorce/README.md
+++ b/examples/2-regrid-evaluate-gorce/README.md
@@ -1,0 +1,81 @@
+# 2 - Diffusion state restart file generation and evaluation
+
+This example demonstrates the full pipeline for generating upscaled NEMO restart files from diffusion model predictions and evaluating them. It uses the GORCE configuration with 1-degree coarse predictions upscaled to 0.25-degree resolution.
+
+Data is available from two Zenodo repositories:
+- Diffusion model outputs: https://zenodo.org/records/16941776
+- Reference restart files and mesh masks: https://zenodo.org/records/19557419
+
+## Prerequisites
+
+Install xESMF for regridding:
+
+```bash
+conda install -c conda-forge xesmf
+```
+
+Install the nemo-spinup-restart tool (from the repo root):
+
+```bash
+pip install ./nemo-spinup-restart
+```
+
+Install nemo-spinup-evaluation (from the repo root):
+
+```bash
+pip install ./nemo-spinup-evaluation
+```
+
+## Data setup
+
+Download data from both Zenodo repositories and organise into the following structure:
+
+```
+data/
+├── diffusion_states/
+│   └── chamon_C2_clean/       # from generated_npy_files.zip (zenodo/16941776)
+│       ├── toce.npy
+│       ├── soce.npy
+│       └── ssh.npy
+├── 100-reference/             # from upscale-example.zip (zenodo/19557419)
+│   ├── DINO_00000002_restart.nc
+│   ├── mesh_mask.nc
+│   └── namelist_cfg
+└── 025-reference/             # from upscale-example.zip (zenodo/19557419)
+    ├── DINO_10800000_restart.nc
+    └── mesh_mask.nc
+```
+
+## Regrid and upscale
+
+Generate a 0.25-degree restart file from the diffusion model predictions:
+
+```bash
+bash upscale.sh
+```
+
+This runs the `nemo-upscale` tool which:
+1. Loads the diffusion model numpy predictions (temperature, salinity, SSH)
+2. Creates a coarse (1-degree) restart file from the predictions
+3. Regrids to fine (0.25-degree) resolution using xESMF bilinear interpolation
+4. Applies the fine resolution mask and zeros out velocities for NEMO to recompute
+
+Output is written to `./generated/`.
+
+## Evaluate using nemo-spinup-evaluationuation
+
+Evaluate the generated restart file against reference diagnostics:
+
+```bash
+bash evaluate.sh
+```
+
+Results are saved to `./results/`.
+
+## Running the full pipeline
+
+To run both steps in sequence:
+
+```bash
+bash upscale.sh && bash evaluate.sh
+```

--- a/examples/2-regrid-evaluate-gorce/README.md
+++ b/examples/2-regrid-evaluate-gorce/README.md
@@ -86,6 +86,20 @@ bash evaluate.sh
 
 Results are saved to `./results/` with prefixes `gen-C2-100` and `gen-C2-025`.
 
+## Results
+
+| Metric | Coarse (1°) | Fine (0.25°) |
+|---|---|---|
+| Density (from file) | 0.1875 | 0.1920 |
+| Density (computed) | 0.2102 | 0.2161 |
+| Temperature 500m 30NS | 10.5851 | 10.5861 |
+| Temperature BW box | 3.5304 | 3.5432 |
+| Temperature DW box | 3.6499 | 3.6545 |
+| ACC Drake Passage | 257.2559 | 0.0000 |
+| NASTG BSF max | 35.4295 | 0.0000 |
+
+Note: ACC Drake Passage and NASTG BSF max are zero at fine resolution because velocities are zeroed out in the upscaled restart for NEMO to recompute.
+
 ## Running the full pipeline
 
 To run both steps in sequence:

--- a/examples/2-regrid-evaluate-gorce/README.md
+++ b/examples/2-regrid-evaluate-gorce/README.md
@@ -36,8 +36,8 @@ bash download-data.sh
 
 Or download manually:
 
-1. **Diffusion model outputs** from https://zenodo.org/records/16941776 — download `generated_npy_files.zip` and extract the `chamon_C2_clean/` directory into `data/diffusion_states/`.
-2. **Reference data** from https://zenodo.org/records/19474413 — download `regrid-evaluate.zip` and extract into `data/`.
+1. **Diffusion model outputs** from https://zenodo.org/records/16941776 - download `generated_npy_files.zip` and extract the `chamon_C2_clean/` directory into `data/diffusion_states/`.
+2. **Reference data** from https://zenodo.org/records/19474413 - download `regrid-evaluate.zip` and extract into `data/`.
 
 The expected directory structure is:
 
@@ -77,8 +77,8 @@ Output is written to `./generated/coarse/` and `./generated/fine/`.
 
 Evaluate the generated restart files at both resolutions. There are separate configs for the coarse (1-degree) and fine (0.25-degree) restart files:
 
-- `gen-setup-100.yaml` — evaluates the coarse restart
-- `gen-setup-025.yaml` — evaluates the fine restart
+- `gen-setup-100.yaml` - evaluates the coarse restart
+- `gen-setup-025.yaml` - evaluates the fine restart
 
 ```bash
 bash evaluate.sh

--- a/examples/2-regrid-evaluate-gorce/README.md
+++ b/examples/2-regrid-evaluate-gorce/README.md
@@ -28,20 +28,31 @@ pip install ./nemo-spinup-evaluation
 
 ## Data setup
 
-Download data from both Zenodo repositories and organise into the following structure:
+Download data from both Zenodo repositories using the provided script:
+
+```bash
+bash download-data.sh
+```
+
+Or download manually:
+
+1. **Diffusion model outputs** from https://zenodo.org/records/16941776 — download `generated_npy_files.zip` and extract the `chamon_C2_clean/` directory into `data/diffusion_states/`.
+2. **Reference data** from https://zenodo.org/records/19474413 — download `regrid-evaluate.zip` and extract into `data/`.
+
+The expected directory structure is:
 
 ```
 data/
 ├── diffusion_states/
-│   └── chamon_C2_clean/       # from generated_npy_files.zip (zenodo/16941776)
+│   └── chamon_C2_clean/
 │       ├── toce.npy
 │       ├── soce.npy
 │       └── ssh.npy
-├── 100-reference/             # from upscale-example.zip (zenodo/19557419)
+├── 100-reference/
 │   ├── DINO_00000002_restart.nc
 │   ├── mesh_mask.nc
 │   └── namelist_cfg
-└── 025-reference/             # from upscale-example.zip (zenodo/19557419)
+└── 025-reference/
     ├── DINO_10800000_restart.nc
     └── mesh_mask.nc
 ```

--- a/examples/2-regrid-evaluate-gorce/download-data.sh
+++ b/examples/2-regrid-evaluate-gorce/download-data.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+DATA_DIR="data"
+
+# --- Diffusion model outputs (https://zenodo.org/records/16941776) ---
+DIFFUSION_ZIP="generated_npy_files.zip"
+DIFFUSION_URL="https://zenodo.org/records/16941776/files/${DIFFUSION_ZIP}"
+
+echo "Downloading diffusion model outputs..."
+mkdir -p "${DATA_DIR}/diffusion_states"
+curl -L -o "${DIFFUSION_ZIP}" "${DIFFUSION_URL}"
+unzip -o "${DIFFUSION_ZIP}" "generated_npy_files/chamon_C2_clean/*"
+mv generated_npy_files/chamon_C2_clean "${DATA_DIR}/diffusion_states/"
+rmdir generated_npy_files
+rm "${DIFFUSION_ZIP}"
+
+# --- Reference data (https://zenodo.org/records/19557419) ---
+REFERENCE_ZIP="regrid-evaluate.zip"
+REFERENCE_URL="https://zenodo.org/records/19557419/files/${REFERENCE_ZIP}"
+
+echo "Downloading reference data..."
+curl -L -o "${REFERENCE_ZIP}" "${REFERENCE_URL}"
+unzip -o "${REFERENCE_ZIP}" -d "${DATA_DIR}"
+rm "${REFERENCE_ZIP}"
+
+echo "Done. Data downloaded to ${DATA_DIR}/"

--- a/examples/2-regrid-evaluate-gorce/evaluate.sh
+++ b/examples/2-regrid-evaluate-gorce/evaluate.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Evaluate the generated restart file using nemo-spinup-evaluation
+
+set -euo pipefail
+
+INDIR="$(dirname "$(realpath "$0")")"
+CONFIG="${INDIR}/gen-setup.yaml"
+DATA_DIR="${INDIR}/generated"
+RESULTS_DIR="${INDIR}/results"
+
+mkdir -p "${RESULTS_DIR}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Error: Evaluation configuration file not found at $CONFIG"
+    exit 1
+fi
+
+echo "==> Evaluating generated restart file"
+nemo-spinup-evaluation \
+    --sim-path "${DATA_DIR}" \
+    --config "${CONFIG}" \
+    --mode restart \
+    --results-dir "${RESULTS_DIR}"
+
+echo "Evaluation complete. Results are saved in: ${RESULTS_DIR}"

--- a/examples/2-regrid-evaluate-gorce/evaluate.sh
+++ b/examples/2-regrid-evaluate-gorce/evaluate.sh
@@ -1,25 +1,27 @@
 #!/bin/bash
-# Evaluate the generated restart file using nemo-spinup-evaluation
+# Evaluate generated restart files using nemo-spinup-evaluation
 
 set -euo pipefail
 
 INDIR="$(dirname "$(realpath "$0")")"
-CONFIG="${INDIR}/gen-setup.yaml"
-DATA_DIR="${INDIR}/generated"
 RESULTS_DIR="${INDIR}/results"
 
 mkdir -p "${RESULTS_DIR}"
 
-if [ ! -f "$CONFIG" ]; then
-    echo "Error: Evaluation configuration file not found at $CONFIG"
-    exit 1
-fi
-
-echo "==> Evaluating generated restart file"
+echo "==> Evaluating 1-degree (coarse) restart"
 nemo-spinup-evaluation \
-    --sim-path "${DATA_DIR}" \
-    --config "${CONFIG}" \
+    --config "${INDIR}/gen-setup-100.yaml" \
+    --sim-path "${INDIR}/generated/coarse" \
     --mode restart \
-    --results-dir "${RESULTS_DIR}"
+    --results-dir "${RESULTS_DIR}" \
+    --result-file-prefix gen-C2-100
+
+echo "==> Evaluating 0.25-degree (fine) restart"
+nemo-spinup-evaluation \
+    --config "${INDIR}/gen-setup-025.yaml" \
+    --sim-path "${INDIR}/generated/fine" \
+    --mode restart \
+    --results-dir "${RESULTS_DIR}" \
+    --result-file-prefix gen-C2-025
 
 echo "Evaluation complete. Results are saved in: ${RESULTS_DIR}"

--- a/examples/2-regrid-evaluate-gorce/gen-setup-025.yaml
+++ b/examples/2-regrid-evaluate-gorce/gen-setup-025.yaml
@@ -1,0 +1,6 @@
+# gen-setup-025.yaml
+# Evaluation configuration for generated 0.25-degree (fine) restart files
+
+mesh_mask: mesh_mask.nc
+
+restart_files: 'generated_restart_C2_fine'

--- a/examples/2-regrid-evaluate-gorce/gen-setup-100.yaml
+++ b/examples/2-regrid-evaluate-gorce/gen-setup-100.yaml
@@ -1,0 +1,6 @@
+# gen-setup-100.yaml
+# Evaluation configuration for generated 1-degree (coarse) restart files
+
+mesh_mask: mesh_mask.nc
+
+restart_files: 'generated_restart_C2_coarse'

--- a/examples/2-regrid-evaluate-gorce/gen-setup.yaml
+++ b/examples/2-regrid-evaluate-gorce/gen-setup.yaml
@@ -1,0 +1,6 @@
+# gen-setup.yaml
+# Evaluation configuration for generated 0.25-degree restart files
+
+mesh_mask: data/025-reference/mesh_mask.nc
+
+restart_files: 'generated_restart_C2'

--- a/examples/2-regrid-evaluate-gorce/gen-setup.yaml
+++ b/examples/2-regrid-evaluate-gorce/gen-setup.yaml
@@ -1,6 +1,0 @@
-# gen-setup.yaml
-# Evaluation configuration for generated 0.25-degree restart files
-
-mesh_mask: data/025-reference/mesh_mask.nc
-
-restart_files: 'generated_restart_C2'

--- a/examples/2-regrid-evaluate-gorce/results/gen-C2-025_restart.csv
+++ b/examples/2-regrid-evaluate-gorce/results/gen-C2-025_restart.csv
@@ -1,0 +1,7 @@
+# Metric Evaluation
+# Base Directory: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/fine
+# Mesh Mask: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/fine/mesh_mask.nc
+# Restart File: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/fine/generated_restart_C2_fine.nc
+#
+timestamp,check_density_from_file,check_density_computed,temperature_500m_30NS_metric,temperature_BWbox_metric,temperature_DWbox_metric,ACC_Drake_metric,ACC_Drake_metric_2,NASTG_BSF_max
+21312000.0,0.192032,0.216127,10.586050,3.543219,3.654454,0.000000,0.000000,0.000000

--- a/examples/2-regrid-evaluate-gorce/results/gen-C2-025_restart_summary.csv
+++ b/examples/2-regrid-evaluate-gorce/results/gen-C2-025_restart_summary.csv
@@ -1,0 +1,6 @@
+# Metric Evaluation
+# Base Directory: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/fine
+# Mesh Mask: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/fine/mesh_mask.nc
+# Restart File: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/fine/generated_restart_C2_fine.nc
+#
+metric

--- a/examples/2-regrid-evaluate-gorce/results/gen-C2-100_restart.csv
+++ b/examples/2-regrid-evaluate-gorce/results/gen-C2-100_restart.csv
@@ -1,0 +1,7 @@
+# Metric Evaluation
+# Base Directory: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/coarse
+# Mesh Mask: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/coarse/mesh_mask.nc
+# Restart File: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/coarse/generated_restart_C2_coarse.nc
+#
+timestamp,check_density_from_file,check_density_computed,temperature_500m_30NS_metric,temperature_BWbox_metric,temperature_DWbox_metric,ACC_Drake_metric,ACC_Drake_metric_2,NASTG_BSF_max
+21312000.0,0.187501,0.210170,10.585099,3.530420,3.649877,257.255904,257.255904,35.429539

--- a/examples/2-regrid-evaluate-gorce/results/gen-C2-100_restart_summary.csv
+++ b/examples/2-regrid-evaluate-gorce/results/gen-C2-100_restart_summary.csv
@@ -1,0 +1,6 @@
+# Metric Evaluation
+# Base Directory: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/coarse
+# Mesh Mask: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/coarse/mesh_mask.nc
+# Restart File: /Users/matt/work/nemo/nemo-spinup-bench/examples/2-regrid-evaluate-gorce/generated/coarse/generated_restart_C2_coarse.nc
+#
+metric

--- a/examples/2-regrid-evaluate-gorce/upscale.sh
+++ b/examples/2-regrid-evaluate-gorce/upscale.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Upscale diffusion model predictions from 1-degree to 0.25-degree restart files
+# using nemo-upscale from nemo-spinup-restart.
+#
+# Requires: xesmf (conda install -c conda-forge xesmf)
+
+set -euo pipefail
+
+INDIR="$(dirname "$(realpath "$0")")"
+DATA_DIR="${INDIR}/data"
+OUTPUT_DIR="${INDIR}/generated"
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "==> Upscaling diffusion predictions to 0.25-degree restart file"
+nemo-upscale upscale \
+    --predictions-dir "${DATA_DIR}/diffusion_states/chamon_C2_clean/" \
+    --coarse-template "${DATA_DIR}/100-reference/DINO_00000002_restart.nc" \
+    --coarse-mask     "${DATA_DIR}/100-reference/mesh_mask.nc" \
+    --coarse-namelist "${DATA_DIR}/100-reference/namelist_cfg" \
+    --fine-template   "${DATA_DIR}/025-reference/DINO_10800000_restart.nc" \
+    --fine-mask       "${DATA_DIR}/025-reference/mesh_mask.nc" \
+    --name            C2 \
+    --time-index      4 \
+    --output-dir      "${OUTPUT_DIR}"
+
+echo "Done. Output in: ${OUTPUT_DIR}"

--- a/examples/2-regrid-evaluate-gorce/upscale.sh
+++ b/examples/2-regrid-evaluate-gorce/upscale.sh
@@ -24,4 +24,13 @@ nemo-upscale upscale \
     --time-index      4 \
     --output-dir      "${OUTPUT_DIR}"
 
+# Move restart files into resolution-specific directories with mesh mask symlinks
+mkdir -p "${OUTPUT_DIR}/coarse" "${OUTPUT_DIR}/fine"
+
+mv "${OUTPUT_DIR}/generated_restart_C2_coarse.nc" "${OUTPUT_DIR}/coarse/"
+mv "${OUTPUT_DIR}/generated_restart_C2_fine.nc"   "${OUTPUT_DIR}/fine/"
+
+ln -sf "${DATA_DIR}/100-reference/mesh_mask.nc" "${OUTPUT_DIR}/coarse/mesh_mask.nc"
+ln -sf "${DATA_DIR}/025-reference/mesh_mask.nc" "${OUTPUT_DIR}/fine/mesh_mask.nc"
+
 echo "Done. Output in: ${OUTPUT_DIR}"


### PR DESCRIPTION
This takes the current example in `nemo-spinup-restart` and reproduces it here: 

TODOs before merge:
- [x] Pipeline proceeds end to end. 
- [x] Upload reference data and 
- [x] upload generated output to [zenodo](https://zenodo.org/records/16941776) 

Fix 
- [ ] New mapping approach in spinup-eval